### PR TITLE
Update to failing unit test for shiny 1.6 release

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -54,7 +54,9 @@ Suggests:
     systemPipeR, 
     knitr, 
     rmarkdown
-Remotes: rstudio/shiny
+Remotes:
+    rstudio/htmltools, 
+    rstudio/shiny
 VignetteBuilder: knitr
 biocViews: Infrastructure, DataImport, Sequencing, QualityControl, ReportWriting, ExperimentalDesign, Clustering
 License: Artistic-2.0

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -54,6 +54,7 @@ Suggests:
     systemPipeR, 
     knitr, 
     rmarkdown
+Remotes: rstudio/shiny
 VignetteBuilder: knitr
 biocViews: Infrastructure, DataImport, Sequencing, QualityControl, ReportWriting, ExperimentalDesign, Clustering
 License: Artistic-2.0

--- a/tests/testthat/_snaps/02interactive_funcs.md
+++ b/tests/testthat/_snaps/02interactive_funcs.md
@@ -1,0 +1,23 @@
+# textInputGroup func
+
+    <div class="row">
+      <div class="col-sm-9" style="padding-right: 0; bottom: 10px">
+        <div>
+          <label for="id1"></label>
+          <span class="text-input-clearable" style="background-color: #f5f5f5;">
+            <input id="id1" type="text" value="" placeholder=""/>
+            <span id="clear_input"
+                     class="glyphicon glyphicon-remove"></span>
+          </span>
+        </div>
+        <script>clearText('id1')</script>
+      </div>
+      <div class="col-sm-3" style="padding-left: 10px; bottom: 10px">
+        <br/>
+        <button id="id2" type="button" class="btn btn-default action-button">
+          <i class="fa fa-paper-plane" role="presentation" aria-label="paper-plane icon"></i>
+          
+        </button>
+      </div>
+    </div>
+

--- a/tests/testthat/test-02interactive_funcs.R
+++ b/tests/testthat/test-02interactive_funcs.R
@@ -232,30 +232,10 @@ expect_equal(
 # </div>
 # <script>clearText('input1')</script>
 
-context("textInputGroup func")
-expect_equal(
-    openssl::md5(textInputGroup("id1", "id2") %>% as.character()) %>%
-        as.character(),
-    "61676e7c8d92fac43caf6554b832163c"
-)
-# <div class="row">
-#     <div class="col-sm-9" style="padding-right: 0; bottom: 10px">
-#       <div>
-#         <label for="id1"></label>
-#         <span class="text-input-clearable" style="background-color: #f5f5f5;">
-#           <input id="id1" type="text" value="" placeholder=""/>
-#           <span id="clear_input" class="glyphicon glyphicon-remove"></span>
-#         </span>
-#       </div>
-#       <script>clearText('id1')</script>
-#     </div>
-#     <div class="col-sm-3" style="padding-left: 10px; bottom: 10px">
-#       <br/>
-#       <button id="id2" type="button" class="btn btn-default action-button">
-#           <i class="fa fa-paper-plane"></i>
-#       </button>
-#     </div>
-# </div>
+test_that("textInputGroup func", {
+    local_edition(3)
+    expect_snapshot_output(textInputGroup("id1", "id2"))
+})
 
 context("tabTitle func")
 expect_equal(


### PR DESCRIPTION
In the next version of shiny (which we plan on submitting to CRAN in a week or so), we've made several changes to HTML/CSS markup which causes this systemPipeShiny unit test to fail (in a non-meaningful way), and so we ask you to submit a new version of systemPipeShiny to CRAN as soon as possible to address this issue.

This PR fixes the problem by updating your failing test expectation to use the new `testthat::expect_snapshot_output()` which provides a much better experience for managing such "snapshot-based tests" and encourages best practices (i.e., disabling these tests on CRAN).  This way, you'll still be notified of any changes through local or CI-based testing, but we can continue to make HTML/CSS changes to shiny without requiring another release of systemPipeShiny. I _highly_ recommend updating your other tests in this file to do the same, so you won't have to keep releasing a new version of systemPipeShiny everytime we change something in shiny.

Please let me know if you have any questions and send a new version of systemPipeShiny to CRAN with these updates to your test expectations as soon as possible.